### PR TITLE
fix: paragraph width on mobile devices

### DIFF
--- a/www/css/index.css
+++ b/www/css/index.css
@@ -47,7 +47,8 @@ div.shannon {
 }
 
 p {
-  width: 440px;
+  width: 100%;
+  max-width: 440px;
   text-align: left;
   display: block;
   margin-left: auto;


### PR DESCRIPTION
On devices with screen widths below 440px (which is still a lot of devices), the text was cut off and would start to scroll.